### PR TITLE
Replace locallyMovedSegments with ObliterateInfo

### DIFF
--- a/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
@@ -652,6 +652,8 @@ export interface ObliterateInfo {
     // (undocumented)
     refSeq: number;
     // (undocumented)
+    segmentGroup: SegmentGroup | undefined;
+    // (undocumented)
     seq: number;
     // (undocumented)
     start: LocalReferencePosition;

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1181,15 +1181,18 @@ export class MergeTree {
 			const deltaSegments: IMergeTreeSegmentDelta[] = [];
 			const overlappingRemoves: boolean[] = [];
 			pendingSegmentGroup.segments.map((pendingSegment: ISegmentLeaf) => {
+				const localMovedSeq = pendingSegment.localMovedSeq;
 				const overlappingRemove = !pendingSegment.ack(pendingSegmentGroup, opArgs);
 
 				overwrite = overlappingRemove || overwrite;
 
-				if (
-					opArgs.op.type === MergeTreeDeltaType.OBLITERATE &&
-					seq !== this.moveSeqs[this.moveSeqs.length - 1]
-				) {
-					this.moveSeqs.push(seq);
+				if (opArgs.op.type === MergeTreeDeltaType.OBLITERATE) {
+					if (seq !== this.moveSeqs[this.moveSeqs.length - 1]) {
+						this.moveSeqs.push(seq);
+					}
+					if (localMovedSeq !== undefined) {
+						this.localMoveSeqs.delete(localMovedSeq);
+					}
 				}
 
 				overlappingRemoves.push(overlappingRemove);

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -404,6 +404,7 @@ export interface ObliterateInfo {
 	clientId: number;
 	seq: number;
 	localSeq: number | undefined;
+	segmentGroup: SegmentGroup | undefined;
 }
 
 /**


### PR DESCRIPTION
Replace locallyMovedSegments with ObliterateInfo. Rather than having a secondary segment group that needs to be independently managed, this change just reuses the original obliterates segment group. 