### PR TITLE
Move reference creation out of nodeMap

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1931,7 +1931,7 @@ export class MergeTree {
 		const normalizedStartPos = startPos === "start" || startPos === undefined ? 0 : startPos;
 		const normalizedEndPos =
 			endPos === "end" || endPos === undefined
-				? this.root.mergeTree?.getLength(refSeq, clientId) ?? 0
+				? this.getLength(refSeq, clientId)
 				: endPos;
 
 		const { segment: startSeg } = this.getContainingSegment(

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1930,7 +1930,7 @@ export class MergeTree {
 		};
 		const normalizedStartPos = startPos === "start" || startPos === undefined ? 0 : startPos;
 		const normalizedEndPos =
-			endPos === "end" || endPos === undefined
+			endPos === "end" || endPos === undefined || endPos > this.getLength(refSeq, clientId)
 				? this.getLength(refSeq, clientId)
 				: endPos;
 

--- a/packages/dds/merge-tree/src/sequencePlace.ts
+++ b/packages/dds/merge-tree/src/sequencePlace.ts
@@ -87,3 +87,19 @@ export function endpointPosAndSide(
 		endPos,
 	};
 }
+
+/**
+ * Returns the given place in InteriorSequencePlace form.
+ */
+export function normalizePlace(place: SequencePlace): InteriorSequencePlace {
+	if (typeof place === "number") {
+		return { pos: place, side: Side.Before };
+	}
+	if (place === "start") {
+		return { pos: -1, side: Side.After };
+	}
+	if (place === "end") {
+		return { pos: -1, side: Side.Before };
+	}
+	return place;
+}

--- a/packages/dds/merge-tree/src/sequencePlace.ts
+++ b/packages/dds/merge-tree/src/sequencePlace.ts
@@ -87,19 +87,3 @@ export function endpointPosAndSide(
 		endPos,
 	};
 }
-
-/**
- * Returns the given place in InteriorSequencePlace form.
- */
-export function normalizePlace(place: SequencePlace): InteriorSequencePlace {
-	if (typeof place === "number") {
-		return { pos: place, side: Side.Before };
-	}
-	if (place === "start") {
-		return { pos: -1, side: Side.After };
-	}
-	if (place === "end") {
-		return { pos: -1, side: Side.Before };
-	}
-	return place;
-}


### PR DESCRIPTION
Tests not passing: 
- obliterate.reconnect.spec.ts: "deletes concurrently inserted segment between group ops" 