### PR TITLE
Add loadPendingChannels to IFluidDataStoreChannel interface

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -23,7 +23,6 @@ import {
 	type ISnapshotTree,
 	type ISequencedDocumentMessage,
 	SummaryType,
-	type ISummaryTree,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	buildSnapshotTree,
@@ -1769,14 +1768,7 @@ export class ChannelCollection
 
 				// Realize the datastore runtime and load the pending channels into it
 				const channel = await existingContext.realize();
-				// Cast to access the loadPendingChannels method (from FluidDataStoreRuntime)
-				if ("loadPendingChannels" in channel) {
-					(
-						channel as {
-							loadPendingChannels: (channels: ISummaryTree) => void;
-						}
-					).loadPendingChannels(channelsTree);
-				}
+				channel.loadPendingChannels?.(channelsTree);
 			}
 		}
 	}

--- a/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
@@ -67,7 +67,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     get isAttached(): boolean;
     readonly isReadOnly: () => boolean;
-    loadPendingChannels(pendingChannelSnapshots: ReadonlyMap<string, ISnapshotTree>): void;
+    loadPendingChannels(channelsTree: ISummaryTree): void;
     // (undocumented)
     get logger(): ITelemetryLoggerExt;
     makeVisibleAndAttachGraph(): void;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -137,6 +137,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
+    loadPendingChannels?(channelsTree: ISummaryTree): void;
     makeVisibleAndAttachGraph(): void;
     notifyReadOnlyState?(readonly: boolean): void;
     readonly policies?: IFluidDataStorePolicies;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
@@ -128,6 +128,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
+    loadPendingChannels?(channelsTree: ISummaryTree): void;
     makeVisibleAndAttachGraph(): void;
     notifyReadOnlyState?(readonly: boolean): void;
     readonly policies?: IFluidDataStorePolicies;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -24,6 +24,7 @@ import type {
 	IDocumentMessage,
 	ISnapshotTree,
 	ISequencedDocumentMessage,
+	ISummaryTree,
 } from "@fluidframework/driver-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 
@@ -452,6 +453,13 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	request(request: IRequest): Promise<IResponse>;
 
 	setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
+
+	/**
+	 * Load pending channels from pending attachment summaries.
+	 * Called during container load to rehydrate channels that were referenced but not yet attached.
+	 * @param channelsTree - The summary tree containing the pending channels to load.
+	 */
+	loadPendingChannels?(channelsTree: ISummaryTree): void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional `loadPendingChannels?(channelsTree: ISummaryTree): void` to `IFluidDataStoreChannel` interface
- Simplify `channelCollection.ts` to use type-safe optional chaining instead of duck-typed cast

## Test plan
- Existing tests should pass

🤖 Generated with [Claude Code](https://claude.ai/code)